### PR TITLE
Update logo credit & fix contact link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,7 @@ slogan: 'Connecting imaging researchers with data and computing resources on the
 description: 'This is the homepage for the consortium developing the NCI Imaging Data Commons.'
 
 # The credits show up in the includes/_footer.html – It would be nice of you to leave a link to Phlow or Feeling Responsive as a thank you :)
-credits: '<p>NCI Imaging Data Commons consortium is supported by the contract number 19X037Q from Leidos Biomedical Research under Task Order HHSN26100071 from NCI.</p><p>This website is based on <a href="http://phlow.github.io/feeling-responsive/">Feeling Responsive</a> theme.</p><p>Imaging Data Commons logo designed by <a href="https://www.mcgill.ca/medphys/academic/current-students/zaki-ahmed">Zaki Ahmed</a>.</p>'
+credits: '<p>NCI Imaging Data Commons consortium is supported by the contract number 19X037Q from Leidos Biomedical Research under Task Order HHSN26100071 from NCI.</p><p>This website is based on <a href="http://phlow.github.io/feeling-responsive/">Feeling Responsive</a> theme.</p><p>Imaging Data Commons logo designed by <a href="https://github.com/notZaki">Zaki Ahmed</a>.</p>'
 
 # Main author of the website
 # See > authors.yml

--- a/_data/services.yml
+++ b/_data/services.yml
@@ -1,7 +1,7 @@
 - menu_name: "Services"
 
 - name: "Contact"
-  url: "/contact/"
+  url: "https://forms.gle/kWpebkVphimJanv77"
   title: "Contact"
 
 - name: "RSS"

--- a/_includes/_navigation.html
+++ b/_includes/_navigation.html
@@ -29,10 +29,13 @@
 
               {% if link.url contains 'http' %}
                 {% assign domain = '' %}
+                {% assign _baseurl = '' %}
               {% elsif link.url == '#' %}
                 {% assign domain = '' %}
+                {% assign _baseurl = site.baseurl %}
               {% else %}
                 {% assign domain = site.url %}
+                {% assign _baseurl = site.baseurl %}
               {% endif %}
 
           {% comment %}   If there are links for right side begin   {% endcomment %}
@@ -40,7 +43,7 @@
             {% comment %}   If right side WITHOUT dropdown menu do   {% endcomment %}
             {% if link.dropdown == nil %}
               <li class="divider"></li>
-              <li{% if link.url == page.url %} class="active"{% elsif page.homepage == true and link.url == '/' %} class="active"{% endif %}><a {% if link.class %}class="{{link.class}}"{% endif %} href="{{ domain }}{{ site.baseurl }}{{ link.url }}"{% if link.url contains 'http' %} target="_blank"{% endif %}>{{ link.title | escape }}</a></li>
+              <li{% if link.url == page.url %} class="active"{% elsif page.homepage == true and link.url == '/' %} class="active"{% endif %}><a {% if link.class %}class="{{link.class}}"{% endif %} href="{{ domain }}{{ _baseurl }}{{ link.url }}"{% if link.url contains 'http' %} target="_blank"{% endif %}>{{ link.title | escape }}</a></li>
 
             {% comment %}   If right side WITH dropdown menu do   {% endcomment %}
             {% else %}


### PR DESCRIPTION
[Preview here](https://notzaki.github.io/idc-feeling-responsive/)

The "Contact" link was pre-pending the domain name. Not sure why it does that. 
Anyways, it becomes a problem if `_data/navigation.yml` contains external links. 
This PR removes that behaviour if the `url` entry contains `http`.

I also changed the url for the logo credit. The old link was to my student page, which will likely be gone at some point.